### PR TITLE
Fixes different column count after rotation

### DIFF
--- a/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridView.java
+++ b/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridView.java
@@ -17,6 +17,7 @@ public class AsymmetricGridView extends ListView {
 
     private static final int DEFAULT_COLUMN_COUNT = 2;
     private static final String TAG = "AsymmetricGridView";
+	private boolean requestedColumnCountCalled = false;
     protected int numColumns = DEFAULT_COLUMN_COUNT;
     protected int requestedHorizontalSpacing;
     protected int requestedColumnWidth;
@@ -90,6 +91,7 @@ public class AsymmetricGridView extends ListView {
 
     public void setRequestedColumnCount(int requestedColumnCount) {
         this.requestedColumnCount = requestedColumnCount;
+	    this.requestedColumnCountCalled = true;
     }
 
     public int getRequestedHorizontalSpacing() {
@@ -158,7 +160,9 @@ public class AsymmetricGridView extends ListView {
         allowReordering = ss.allowReordering;
         debugging = ss.debugging;
         numColumns = ss.numColumns;
-        requestedColumnCount = ss.requestedColumnCount;
+	    if (!requestedColumnCountCalled) {
+		    requestedColumnCount = ss.requestedColumnCount;
+	    }
         requestedColumnWidth = ss.requestedColumnWidth;
         requestedHorizontalSpacing = ss.requestedHorizontalSpacing;
 


### PR DESCRIPTION
Now allows to have a different column count for each screen orientation.

When library had requestedColumnCount set on one screen orientation and wanted to have different requestedColumnCount on other screen orientation, library overwrote the requestedColumnCount settings with what was stored in Saved Instance State.
Library no longer ignores changes which happens to requestedColumnCount count before
onRestoreInstanceState is called.

Portrait
![2015-01-23 10 31 10](https://cloud.githubusercontent.com/assets/7145384/5873111/648055da-a2f3-11e4-9ff7-4e7c9fd0e571.png)

Landscape
![2015-01-23 10 31 18](https://cloud.githubusercontent.com/assets/7145384/5873110/647cc9f6-a2f3-11e4-97be-50d8d5223f4c.png)