### PR TITLE
Simplified Constructor and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ your own adapter to the AsymmetricGridViewAdapter constructor instead of extendi
 In your ``build.gradle`` file:
 
 ```groovy
-
 dependencies {
     compile 'com.felipecsl.asymmetricgridview:library:2.0.1'
 }
 ```
+
+This repository has a new feature. Instead of explicitly wrapping your adapter in the AsymmetricGridViewAdapter you simply call AsymmetricGridView.setAdapter( adapter ) with any old adapter and then it is wrapped and linked under the hood. This constructors are also more consistent with what an Android developer might expect.
 
 In your layout xml:
 
@@ -58,10 +59,8 @@ protected void onCreate(Bundle savedInstanceState) {
     final List<AsymmetricItem> items = new ArrayList<>();
 
     // initialize your items array
-    adapter = new ListAdapter(this, listView, items);
-    AsymmetricGridViewAdapter asymmetricAdapter =
-        new AsymmetricGridViewAdapter<>(this, listView, adapter);
-    listView.setAdapter(asymmetricAdapter);
+    adapter = new ListAdapter(this, items);
+    listView.setAdapter(adapter);
 }
 ```
 

--- a/app/src/main/java/com/felipecsl/asymmetricgridview/app/MainActivity.java
+++ b/app/src/main/java/com/felipecsl/asymmetricgridview/app/MainActivity.java
@@ -15,7 +15,6 @@ import com.felipecsl.asymmetricgridview.app.widget.DefaultListAdapter;
 import com.felipecsl.asymmetricgridview.app.widget.DemoAdapter;
 import com.felipecsl.asymmetricgridview.library.Utils;
 import com.felipecsl.asymmetricgridview.library.widget.AsymmetricGridView;
-import com.felipecsl.asymmetricgridview.library.widget.AsymmetricGridViewAdapter;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -32,7 +31,8 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
   private static final boolean USE_CURSOR_ADAPTER = false;
 
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
+  protected void onCreate(Bundle savedInstanceState)
+  {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
     listView = (AsymmetricGridView) findViewById(R.id.listView);
@@ -53,14 +53,11 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
 
     listView.setRequestedColumnCount(3);
     listView.setRequestedHorizontalSpacing(Utils.dpToPx(this, 3));
-    listView.setAdapter(getNewAdapter());
+    listView.setAdapter( adapter );
     listView.setDebugging(true);
     listView.setOnItemClickListener(this);
   }
 
-  private AsymmetricGridViewAdapter<?> getNewAdapter() {
-    return new AsymmetricGridViewAdapter<>(this, listView, adapter);
-  }
 
   private List<DemoItem> getMoreItems(int qty) {
     List<DemoItem> items = new ArrayList<>();
@@ -146,17 +143,19 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
   private void setNumColumns(int numColumns) {
     listView.setRequestedColumnCount(numColumns);
     listView.determineColumns();
-    listView.setAdapter(getNewAdapter());
+    listView.setAdapter(adapter);
   }
 
   private void setColumnWidth(int columnWidth) {
     listView.setRequestedColumnWidth(Utils.dpToPx(this, columnWidth));
     listView.determineColumns();
-    listView.setAdapter(getNewAdapter());
+    listView.setAdapter(adapter);
   }
 
   @Override public void onItemClick(@NotNull AdapterView<?> parent, @NotNull View view,
       int position, long id) {
     Toast.makeText(this, "Item " + position + " clicked", Toast.LENGTH_SHORT).show();
+
+      adapter.remove( position );
   }
 }

--- a/app/src/main/java/com/felipecsl/asymmetricgridview/app/widget/DefaultCursorAdapter.java
+++ b/app/src/main/java/com/felipecsl/asymmetricgridview/app/widget/DefaultCursorAdapter.java
@@ -3,6 +3,7 @@ package com.felipecsl.asymmetricgridview.app.widget;
 import android.content.Context;
 import android.database.sqlite.SQLiteCursor;
 import android.support.v4.widget.SimpleCursorAdapter;
+import android.util.Log;
 
 import com.felipecsl.asymmetricgridview.app.R;
 import com.felipecsl.asymmetricgridview.app.model.DemoItem;
@@ -46,6 +47,11 @@ public class DefaultCursorAdapter extends SimpleCursorAdapter implements DemoAda
   @Override public void setItems(List<DemoItem> moreItems) {
     swapCursor(new SampleDbAdapter(context).open().deleteAllData().seedDatabase(moreItems)
                    .fetchAllData());
+  }
+
+  @Override
+  public void remove(int position) {
+    Log.d("z", "wut?");
   }
 
   public static class CursorAdapterItem extends DemoItem {

--- a/app/src/main/java/com/felipecsl/asymmetricgridview/app/widget/DefaultListAdapter.java
+++ b/app/src/main/java/com/felipecsl/asymmetricgridview/app/widget/DefaultListAdapter.java
@@ -75,4 +75,9 @@ public class DefaultListAdapter extends ArrayAdapter<DemoItem> implements DemoAd
     clear();
     appendItems(moreItems);
   }
+
+  @Override
+  public void remove(int position) {
+    super.remove( getItem(position) );
+  }
 }

--- a/app/src/main/java/com/felipecsl/asymmetricgridview/app/widget/DemoAdapter.java
+++ b/app/src/main/java/com/felipecsl/asymmetricgridview/app/widget/DemoAdapter.java
@@ -11,4 +11,6 @@ public interface DemoAdapter extends ListAdapter {
   void appendItems(List<DemoItem> newItems);
 
   void setItems(List<DemoItem> moreItems);
+
+  void remove(int position);
 }

--- a/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridView.java
+++ b/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridView.java
@@ -67,7 +67,7 @@ public class AsymmetricGridView extends ListView {
   @Override
   public void setAdapter(@NonNull ListAdapter adapter)
   {
-    gridAdapter = new AsymmetricGridViewAdapter( getContext() , adapter );
+    gridAdapter = ( adapter instanceof AsymmetricGridViewAdapter ) ? (AsymmetricGridViewAdapter) adapter : new AsymmetricGridViewAdapter( getContext() , adapter );
     gridAdapter.setListView( this );
 
     super.setAdapter(gridAdapter);

--- a/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridView.java
+++ b/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridView.java
@@ -65,15 +65,12 @@ public class AsymmetricGridView extends ListView {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public void setAdapter(@NonNull ListAdapter adapter) {
-    if (!(adapter instanceof AsymmetricGridViewAdapter)) {
-      throw new UnsupportedOperationException(
-          "Adapter must be an instance of AsymmetricGridViewAdapter");
-    }
+  public void setAdapter(@NonNull ListAdapter adapter)
+  {
+    gridAdapter = new AsymmetricGridViewAdapter( getContext() , adapter );
+    gridAdapter.setListView( this );
 
-    gridAdapter = (AsymmetricGridViewAdapter) adapter;
-    super.setAdapter(adapter);
+    super.setAdapter(gridAdapter);
 
     gridAdapter.recalculateItemsPerRow();
   }

--- a/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridViewAdapter.java
+++ b/library/src/main/java/com/felipecsl/asymmetricgridview/library/widget/AsymmetricGridViewAdapter.java
@@ -26,10 +26,11 @@ import java.util.List;
 import java.util.Map;
 
 public final class AsymmetricGridViewAdapter<T extends AsymmetricItem> extends BaseAdapter
-    implements View.OnClickListener, View.OnLongClickListener, WrapperListAdapter {
+  implements View.OnClickListener, View.OnLongClickListener, WrapperListAdapter
+  {
 
   private static final String TAG = AsymmetricGridViewAdapter.class.getSimpleName();
-  private final AsymmetricGridView listView;
+  private AsymmetricGridView listView;
   private final Context context;
   private final ListAdapter wrappedAdapter;
   private final Map<Integer, RowInfo<T>> itemsPerRow = new HashMap<>();
@@ -49,13 +50,16 @@ public final class AsymmetricGridViewAdapter<T extends AsymmetricItem> extends B
     }
   }
 
-  public AsymmetricGridViewAdapter(Context context, AsymmetricGridView listView,
-                                   ListAdapter adapter) {
+  public AsymmetricGridViewAdapter(Context context, ListAdapter adapter) {
     this.linearLayoutPool = new ObjectPool<>(new LinearLayoutPoolObjectFactory(context));
     this.wrappedAdapter = adapter;
     this.context = context;
-    this.listView = listView;
     wrappedAdapter.registerDataSetObserver(new GridDataSetObserver());
+  }
+
+  public void setListView( AsymmetricGridView listView )
+  {
+    this.listView = listView;
   }
 
   protected int getRowHeight(AsymmetricItem item) {


### PR DESCRIPTION
I just thought that seeing as the Adapter is final and has a particular need for a reference to the View it was getting a bit verbose. This can be moved into the setAdapter and automatically wrapped by the AsymmetricGridViewAdapter under the hood. Then the developer doesn't have to know about AsymmetricGridViewAdapter.

I also added a removeItem call in the clickItem handler which really shows off the adaptability of your library.

I am assuming that developers have no need to access the AsymmetricGridViewAdapter directly. If that's incorrect ignore this pull request.