### PR TITLE
Update android 28, Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ android:
 after_success:
 - ".buildscript/deploy_snapshot.sh"
 jdk:
-- openjdk7
 - oraclejdk8
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-23.0.1
-  - android-23
+  - build-tools-28.0.3
+  - android-28
   - extra-android-m2repository
   - extra-android-support
   - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
 after_success:
 - ".buildscript/deploy_snapshot.sh"
 jdk:
-- oraclejdk7
+- openjdk7
 - oraclejdk8
 branches:
   except:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 28
         versionCode 2
         versionName "2.0.0"
     }
@@ -18,10 +18,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:support-annotations:24.2.1'
-    compile 'com.android.support:design:24.2.1'
-    compile 'com.android.support:cardview-v7:24.2.1'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
-    compile project(':library')
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:support-annotations:$supportLibVersion"
+    implementation "com.android.support:design:$supportLibVersion"
+    implementation "com.android.support:cardview-v7:$supportLibVersion"
+    implementation "com.android.support:recyclerview-v7:$supportLibVersion"
+    implementation project(':library')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,21 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
+}
+
+ext {
+    supportLibVersion = '28.0.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 04 15:26:24 BRST 2014
+#Sat Oct 13 09:23:02 ICT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 28
     }
 
     compileOptions {
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:24.2.1'
-    compile 'com.android.support:support-annotations:24.2.1'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
+    implementation "com.android.support:support-v4:$supportLibVersion"
+    implementation "com.android.support:support-annotations:$supportLibVersion"
+    implementation "com.android.support:recyclerview-v7:$supportLibVersion"
 }


### PR DESCRIPTION
- Update Gradle Wrapper to `4.6`
- Update TargetSdk to `28`
- Update Support Library `28.0.0`
- Replace all `compile` with `implementation`
- Removed `oraclejdk7` because Travis no longer supported (see travis-ci/travis-ci#7884). Already tried with `openjdk7` but It have issue when download *Gradle* 